### PR TITLE
Replace Ben with version on right

### DIFF
--- a/Source/TeamMate/Windows/SplashScreen.xaml
+++ b/Source/TeamMate/Windows/SplashScreen.xaml
@@ -61,12 +61,13 @@
                                    Visibility="Hidden" />
             <TextBlock Name="StatusText"
                        VerticalAlignment="Bottom"
+                       HorizontalAlignment="Right"
                        FontFamily="Segoe UI Light"
                        Opacity="0.8">
                 <TextBlock.RenderTransform>
                     <TranslateTransform />
                 </TextBlock.RenderTransform>
-                Created by Ben Amodio. For Microsoft Internal Use Only.
+                <Run Text="version " /><Run Text="{x:Static tmm:TeamMateApplicationInfo.FullVersion}" />
             </TextBlock>
         </Grid>
     </Grid>


### PR DESCRIPTION
Looks kinda empty with nothing at the bottom, so I added version on the right, which is "typical" for apps

![image](https://user-images.githubusercontent.com/28568469/124091308-fad0df00-da55-11eb-9904-e1426c863cab.png)