### PR TITLE
"SP324098: Your browser could not complete the operation" when connecting to ADO

### DIFF
--- a/Source/Setup/Product.wxs
+++ b/Source/Setup/Product.wxs
@@ -78,6 +78,7 @@
         <File Source="$(var.WebApi.TargetDir)\Microsoft.VisualStudio.Services.Common.dll" />
         <File Source="$(var.WebApi.TargetDir)\Microsoft.VisualStudio.Services.WebApi.dll" />
         <File Source="$(var.WebApi.TargetDir)\Microsoft.TeamFoundation.Core.WebApi.dll" />
+        <File Source="$(var.WebApi.TargetDir)\Microsoft.TeamFoundation.SourceControl.WebApi.dll" />
         <File Source="$(var.WebApi.TargetDir)\Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll" />
         <File Source="$(var.WebApi.TargetDir)\Newtonsoft.Json.dll" />
         <File Source="$(var.WebApi.TargetDir)\System.Net.Http.Formatting.dll" />

--- a/Source/TeamMate/Services/VstsConnectionService.cs
+++ b/Source/TeamMate/Services/VstsConnectionService.cs
@@ -39,7 +39,11 @@ namespace Microsoft.Tools.TeamMate.Services
         {
             Assert.ParamIsNotNull(projectCollectionUri, "projectCollectionUri");
 
-            VssConnection connection = new VssConnection(projectCollectionUri, new VssClientCredentials());
+            var credentials = new VssClientCredentials();
+            credentials.PromptType = VisualStudio.Services.Common.CredentialPromptType.PromptIfNeeded;
+            credentials.Storage = new VssClientCredentialStorage("TeamMate", "TeamMate");
+
+            VssConnection connection = new VssConnection(projectCollectionUri, credentials);
             using (Log.PerformanceBlock("Authenticating with collection at {0}", projectCollectionUri))
             {
                 await connection.ConnectAsync(cancellationToken);


### PR DESCRIPTION
Fix token storage. Additionally, add missing DLL dependency.