### PR TITLE
Fix sp324098 by using explicit token storage

### DIFF
--- a/Source/TeamMate/Services/VstsClientCredentialCachingStorage.cs
+++ b/Source/TeamMate/Services/VstsClientCredentialCachingStorage.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.VisualStudio.Services.Client;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.Common.TokenStorage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IssuedToken = Microsoft.VisualStudio.Services.Common.IssuedToken;
+
+namespace Microsoft.Tools.TeamMate.Services
+{
+    class VstsClientCredentialCachingStorage : VssClientCredentialStorage
+    {
+        private const string TokenExpirationKey = "ExpirationDateTime";
+        private double TokenLeaseInSeconds;
+
+        public VstsClientCredentialCachingStorage(string storageKind = "VssApp", string storageNamespace = "VisualStudio", double tokenLeaseInSeconds = 86400)
+            : base(storageKind, storageNamespace)
+        {
+            this.TokenLeaseInSeconds = tokenLeaseInSeconds;
+        }
+
+        public override void RemoveToken(Uri serverUrl, IssuedToken token)
+        {
+            this.RemoveToken(serverUrl, token, false);
+        }
+
+        public void RemoveToken(Uri serverUrl, IssuedToken token, bool force)
+        {
+            // Bypassing this allows the token to be stored in local
+            // cache. Token is removed if lease is expired.
+            if (force || token != null && this.IsTokenExpired(token))
+            {
+                base.RemoveToken(serverUrl, token);
+            }
+        }
+
+        public override IssuedToken RetrieveToken(Uri serverUrl, VssCredentialsType credentialsType)
+        {
+            var token = base.RetrieveToken(serverUrl, credentialsType);
+
+            if (token != null)
+            {
+                bool expireToken = this.IsTokenExpired(token);
+                if (expireToken)
+                {
+                    base.RemoveToken(serverUrl, token);
+                    token = null;
+                }
+                else
+                {
+                    // if retrieving the token before it is expired,
+                    // refresh the lease period.
+                    this.RefreshLeaseAndStoreToken(serverUrl, token);
+                    token = base.RetrieveToken(serverUrl, credentialsType);
+                }
+            }
+
+            return token;
+        }
+
+        public override void StoreToken(Uri serverUrl, IssuedToken token)
+        {
+            this.RefreshLeaseAndStoreToken(serverUrl, token);
+        }
+
+        public void ClearAllTokens(Uri url = null)
+        {
+            IEnumerable<VssToken> tokens = this.TokenStorage.RetrieveAll(base.TokenKind).ToList();
+
+            if (url != default(Uri))
+            {
+                tokens = tokens.Where(t => StringComparer.InvariantCultureIgnoreCase.Compare(t.Resource, url.ToString().TrimEnd('/')) == 0);
+            }
+
+            foreach (var token in tokens)
+            {
+                this.TokenStorage.Remove(token);
+            }
+        }
+
+        private void RefreshLeaseAndStoreToken(Uri serverUrl, IssuedToken token)
+        {
+            if (token.Properties == null)
+            {
+                token.Properties = new Dictionary<string, string>();
+            }
+
+            token.Properties[TokenExpirationKey] = this.GetNewExpirationDateTime().ToString();
+
+            base.StoreToken(serverUrl, token);
+        }
+
+        private DateTime GetNewExpirationDateTime()
+        {
+            var now = DateTime.Now;
+
+            // Ensure we don't overflow the max DateTime value
+            var lease = Math.Min((DateTime.MaxValue - now.Add(TimeSpan.FromSeconds(1))).TotalSeconds, this.TokenLeaseInSeconds);
+
+            // ensure we don't have negative leases
+            lease = Math.Max(lease, 0);
+
+            return now.AddSeconds(lease);
+        }
+
+        private bool IsTokenExpired(IssuedToken token)
+        {
+            bool expireToken = true;
+
+            if (token != null && token.Properties.ContainsKey(TokenExpirationKey))
+            {
+                try
+                {
+                    DateTime expiration = Convert.ToDateTime(token.Properties[TokenExpirationKey]);
+
+                    expireToken = DateTime.Compare(DateTime.Now, expiration) >= 0;
+                }
+                catch { }
+            }
+
+            return expireToken;
+        }
+    }
+}

--- a/Source/TeamMate/Services/VstsConnectionService.cs
+++ b/Source/TeamMate/Services/VstsConnectionService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Tools.TeamMate.Services
 
             var credentials = new VssClientCredentials();
             credentials.PromptType = VisualStudio.Services.Common.CredentialPromptType.PromptIfNeeded;
-            credentials.Storage = new VssClientCredentialStorage("TeamMate", "TeamMate");
+            credentials.Storage = GetVssClientCredentialStorage(86400);
 
             VssConnection connection = new VssConnection(projectCollectionUri, credentials);
             using (Log.PerformanceBlock("Authenticating with collection at {0}", projectCollectionUri))
@@ -50,6 +50,10 @@ namespace Microsoft.Tools.TeamMate.Services
             }
 
             return connection;
+        }
+        private static VstsClientCredentialCachingStorage GetVssClientCredentialStorage(double tokenLeaseInSeconds)
+        {
+            return new VstsClientCredentialCachingStorage("TeamMate", "TokenStorage", tokenLeaseInSeconds);
         }
 
         public async Task<ProjectReference> ResolveProjectReferenceAsync(Uri projectCollectionUri, string projectName)

--- a/Source/TeamMate/TeamMate.csproj
+++ b/Source/TeamMate/TeamMate.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Services\SearchService.cs" />
     <Compile Include="Services\SessionService.cs" />
     <Compile Include="Services\UpgradeService.cs" />
+    <Compile Include="Services\VstsClientCredentialCachingStorage.cs" />
     <Compile Include="Services\WorkItemStateService.cs" />
     <Compile Include="Model\Settings\ProjectSettings.cs" />
     <Compile Include="Model\Settings\SettingsBase.cs" />


### PR DESCRIPTION
We are hitting SP324098: Your browser could not complete the operation when trying to connect to ADO. This is because we don't have an explicit token storage and are keeping expired leases around.