### PR TITLE
Show tags in Work Item entries

### DIFF
--- a/Source/TeamMate/Controls/WorkItemRowView.xaml
+++ b/Source/TeamMate/Controls/WorkItemRowView.xaml
@@ -114,10 +114,11 @@
         <TextBlock Name="assignedToTextBlock"
                    Grid.Row="1"
                    Grid.Column="1"
-                   Margin="12,3,0,0"
+                   Margin="12,3,220,0"
                    Text="{Binding BottomLeftValue,
                                   Converter={x:Static tmcv:TeamMateConverters.AssignedTo}}"
-                   TextTrimming="CharacterEllipsis">
+                   TextTrimming="CharacterEllipsis"
+                   TextAlignment="Left">
             <TextBlock.Style>
                 <Style TargetType="TextBlock">
                     <Style.Triggers>
@@ -139,6 +140,25 @@
             <TextBlock.Style>
                 <Style TargetType="TextBlock">
                     <Setter Property="Foreground" Value="Gray" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsFlagged}" Value="True">
+                            <Setter Property="Foreground" Value="#D00E0D" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+        <TextBlock x:Name="tagsBlock"
+            FontFamily="Segoe UI"
+            Foreground="Gray"
+            Grid.Row="1"
+            Grid.Column="1"
+            Margin="370,3,5,0"
+            Text="{Binding BottomRightValue}"
+            TextAlignment="Right"
+            TextTrimming="CharacterEllipsis">
+            <TextBlock.Style>
+                <Style TargetType="{x:Type TextBlock}">
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding IsFlagged}" Value="True">
                             <Setter Property="Foreground" Value="#D00E0D" />

--- a/Source/TeamMate/ViewModels/WorkItemRowViewModel.cs
+++ b/Source/TeamMate/ViewModels/WorkItemRowViewModel.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
         private IDictionary<string, object> additionalFields;
         private string bottomLeftValue;
+        private string bottomRightValue;
         private WorkItemState? workItemState;
         private WorkItem workItem;
 
@@ -151,6 +152,34 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 }
 
                 return this.bottomLeftValue;
+            }
+        }
+
+        public string BottomRightValue
+        {
+            get
+            {
+                if (this.bottomRightValue == null)
+                {
+                    bool first = true;
+
+                    StringBuilder sb = new StringBuilder();
+                    foreach (var tag in Tags)
+                    {
+                        if (!first)
+                        {
+                            sb.Append(" | ");
+                        }
+
+                        first = false;
+
+                        sb.Append(tag);
+                    }
+
+                    this.bottomRightValue = sb.ToString();
+                }
+
+                return this.bottomRightValue;
             }
         }
 


### PR DESCRIPTION
Let's show tags in work item entries. This makes it easier to spot important tags for teams that use it as an important part of their workflow.

Closes #46 