### PR TITLE
Extend PR queries to allow 'Created by' and 'Assigned to' with '@me'

### DIFF
--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Tools.TeamMate.Foundation.Collections;
+﻿using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Microsoft.Tools.TeamMate.Foundation.Collections;
 using Microsoft.Tools.TeamMate.Foundation.Diagnostics;
 using Microsoft.Tools.TeamMate.Foundation.Xml;
 using Microsoft.Tools.TeamMate.Model.Settings;
@@ -74,6 +75,8 @@ namespace Microsoft.Tools.TeamMate.Model
 
             query.Name = e.GetAttribute<string>(Schema.Name);
             query.ReviewStatus = e.GetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus);
+            query.AssignedTo = e.GetAttribute<string>(Schema.AssignedTo);
+            query.CreatedBy = e.GetAttribute<string>(Schema.CreatedBy);
 
             return query;
         }
@@ -140,6 +143,8 @@ namespace Microsoft.Tools.TeamMate.Model
             XElement e = new XElement(Schema.PullRequestQueryInfo);
             e.SetAttribute<string>(Schema.Name, query.Name);
             e.SetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus, query.ReviewStatus);
+            e.SetAttribute<string>(Schema.CreatedBy, query.CreatedBy);
+            e.SetAttribute<string>(Schema.AssignedTo, query.AssignedTo);
 
             return e;
         }
@@ -322,7 +327,7 @@ namespace Microsoft.Tools.TeamMate.Model
             result.SetAttribute<DateTime>(Schema.Date, entry.Date);
 
             WorkItemReference workItemReference = entry.Key as WorkItemReference;
-            PullRequestReference pullRequestReference = entry.Key as PullRequestReference;
+            GitPullRequest pullRequestReference = entry.Key as GitPullRequest;
             if (workItemReference != null)
             {
                 result.Add(WriteWorkItemReference(workItemReference));
@@ -330,8 +335,8 @@ namespace Microsoft.Tools.TeamMate.Model
             else if (pullRequestReference != null)
             {
                 XElement e = new XElement(Schema.PullRequest);
-                e.SetAttribute<Guid>(Schema.PullRequestProjectId, pullRequestReference.ProjectId);
-                e.SetAttribute<int>(Schema.PullRequestId, pullRequestReference.Id);
+                e.SetAttribute<Guid>(Schema.PullRequestProjectId, pullRequestReference.Repository.Id);
+                e.SetAttribute<int>(Schema.PullRequestId, pullRequestReference.PullRequestId);
                 result.Add(e);
             }
             else

--- a/Source/TeamMate/Model/PullRequestQueryInfo.cs
+++ b/Source/TeamMate/Model/PullRequestQueryInfo.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Tools.TeamMate.Model
 
         public string Name { get; set; }
         public PullRequestQueryReviewStatus ReviewStatus { get; set; }
+        public string CreatedBy { get; set; }
+
+        public string AssignedTo { get; set; }
     }
     public enum PullRequestQueryReviewStatus
     {
@@ -26,7 +29,7 @@ namespace Microsoft.Tools.TeamMate.Model
         Completed,
 
         [Description("All")]
-        All
+        All,
     }
 }
 

--- a/Source/TeamMate/TeamMate.csproj
+++ b/Source/TeamMate/TeamMate.csproj
@@ -990,17 +990,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.CommandLine">
-      <Version>5.6.11</Version>
+      <Version>5.8.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="GitVersion.MsBuild">
-      <Version>5.6.11</Version>
+      <Version>5.8.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SimpleInjector">
-      <Version>5.3.1</Version>
+      <Version>5.3.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
             var actionableFilter = new ListViewFilter("Assigned To Me", (o) => ((PullRequestRowViewModel)o).IsAssignedToMe);
             model.Filters.Add(actionableFilter);
+            var createByActionableFilter = new ListViewFilter("Created By Me", (o) => ((PullRequestRowViewModel)o).IsOwnedByMe);
+            model.Filters.Add(createByActionableFilter);
             model.Filters.Add(new ListViewFilter("Pending", (o) => ((PullRequestRowViewModel)o).IsPending));
             model.Filters.Add(new ListViewFilter("Waiting", (o) => ((PullRequestRowViewModel)o).IsWaiting));
             model.Filters.Add(new ListViewFilter("Signed Off", (o) => ((PullRequestRowViewModel)o).IsSignedOff));

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -3,6 +3,8 @@ using Microsoft.Tools.TeamMate.Foundation.Validation;
 using Microsoft.Tools.TeamMate.Foundation.Windows.MVVM;
 using Microsoft.Tools.TeamMate.Model;
 using System;
+using System.Collections;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Microsoft.Tools.TeamMate.ViewModels
@@ -12,6 +14,20 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         private string name;
         private PullRequestQueryInfo queryInfo;
         private PullRequestQueryReviewStatus reviewStatus;
+
+        private string _selectedAssignedTo;
+        private ObservableCollection<string> _assignedTo = new ObservableCollection<string>()
+        {
+            "@me",
+            "",
+        };
+
+        private string _selectedCreatedBy;
+        private ObservableCollection<string> _createdBy = new ObservableCollection<string>()
+        {
+            "@me",
+            "",
+        };
 
         public PullRequestPickerViewModel()
         {
@@ -42,13 +58,75 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             get { return this.reviewStatus; }
             set { SetProperty(ref this.reviewStatus, value); }
         }
+        public IEnumerable AssignedTo
+        {
+            get { return this._assignedTo; }
+        }
+        public string SelectedAssignedTo
+        {
+            get { return this._selectedAssignedTo; }
+            set
+            {
+                this._selectedAssignedTo = value;
+                OnPropertyChanged("SelectedAssignedTo");
+            }
+        }
 
+        public string NewAssignedTo
+        {
+            set
+            {
+                if (SelectedAssignedTo != null)
+                {
+                    return;
+                }
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    this._assignedTo.Add(value);
+                    SelectedAssignedTo = value;
+                }
+            }
+        }
+
+        public IEnumerable CreatedBy
+        {
+            get { return this._createdBy; }
+        }
+        public string SelectedCreatedBy
+        {
+            get { return this._selectedCreatedBy; }
+            set
+            {
+                this._selectedCreatedBy = value;
+                OnPropertyChanged("SelectedCreatedBy");
+            }
+        }
+
+        public string NewCreatedBy
+        {
+            set
+            {
+                if (SelectedCreatedBy != null)
+                {
+                    return;
+                }
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    this._createdBy.Add(value);
+                    SelectedCreatedBy = value;
+                }
+            }
+        }
         private void Invalidate()
         {
             if (this.queryInfo != null)
             {
                 this.Name = this.queryInfo.Name;
                 this.ReviewStatus = this.queryInfo.ReviewStatus;
+                this.SelectedAssignedTo = this.queryInfo.AssignedTo;
+                this.SelectedCreatedBy = this.queryInfo.CreatedBy;
             }
         }
 
@@ -58,6 +136,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             {
                 this.queryInfo.Name = this.Name.Trim();
                 this.queryInfo.ReviewStatus = this.ReviewStatus;
+                this.queryInfo.AssignedTo = this.SelectedAssignedTo;
+                this.queryInfo.CreatedBy = this.SelectedCreatedBy;
             }
         }
 

--- a/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
@@ -160,8 +160,17 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             query.GitPullRequestSearchCriteria = new GitPullRequestSearchCriteria
             {
                 Status = PullRequestQueryInfo.ReviewStatusesMap[this.queryInfo.ReviewStatus],
-                ReviewerId = pc.Identity.Id
             };
+
+            if (this.queryInfo.AssignedTo == "@me")
+            {
+                query.GitPullRequestSearchCriteria.ReviewerId = pc.Identity.Id;
+            }
+
+            if (this.queryInfo.CreatedBy == "@me")
+            {
+                query.GitPullRequestSearchCriteria.CreatorId = pc.Identity.Id;
+            }
 
             return query;
         }

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -73,7 +73,7 @@
                     <ComboBox Grid.Row="2"
                               Margin="82,0,0,-26"
                               ItemsSource="{Binding CreatedBy}"
-                              SelectedItem="{Binding SelectedCreatedByo}"
+                              SelectedItem="{Binding SelectedCreatedBy}"
                               Text="{Binding NewCreatedBy, UpdateSourceTrigger=LostFocus}"
                               Grid.ColumnSpan="2" />
                     <ComboBox Grid.Row="3"

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -1,12 +1,13 @@
-﻿<Window x:Class="Microsoft.Tools.TeamMate.Windows.PullRequestQueryEditorDialog"
+﻿<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:fw="clr-namespace:Microsoft.Tools.TeamMate.Foundation.Windows;assembly=Microsoft.Tools.TeamMate.Foundation"
         xmlns:fwc="clr-namespace:Microsoft.Tools.TeamMate.Foundation.Windows.Controls;assembly=Microsoft.Tools.TeamMate.Foundation"
         xmlns:tmc="clr-namespace:Microsoft.Tools.TeamMate.Controls"
+        xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="Microsoft.Tools.TeamMate.Windows.PullRequestQueryEditorDialog"
         FocusManager.FocusedElement="{Binding ElementName=nameTextBox}"
-        SizeToContent="WidthAndHeight"
-        Style="{StaticResource LyncDialogStyle}">
+        SizeToContent="WidthAndHeight" Height="294"
+        >
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}">
             <Setter Property="Validation.ErrorTemplate" Value="{StaticResource DefaultErrorTemplate}" />
@@ -16,9 +17,21 @@
         </DataTemplate>
 
     </Window.Resources>
+    <Window.Style>
+        <StaticResource ResourceKey="LyncDialogStyle"/>
+    </Window.Style>
     <AdornerDecorator>
         <fwc:DialogPanel Margin="12,0,24,12">
-            <StackPanel Width="400">
+            <fwc:DialogPanel.ButtonPanel>
+                <fwc:ButtonPanel>
+                    <Button x:Name="okButton"
+                            Content="OK"
+                            IsDefault="True"
+                            Style="{StaticResource LyncButtonStyle}" />
+                    <Button Style="{StaticResource LyncButtonStyle}" fw:UI.ButtonType="Cancel" />
+                </fwc:ButtonPanel>
+            </fwc:DialogPanel.ButtonPanel>
+            <StackPanel Width="400" Height="230">
                 <TextBlock Style="{StaticResource LyncDialogTitleStyle}" Text="Pull Request Query"/>
                 <tmc:ValidationErrorView />
                 <Grid Margin="0,12,0,0">
@@ -30,56 +43,46 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
                     <Label Grid.Row="0"
                            Grid.Column="0"
-                           Margin="0,0,6,6">
-                        Name:
-                    </Label>
-                    <TextBox Name="nameTextBox"
+                           Margin="0,0,6,6" Content="Name:"/>
+                    <TextBox x:Name="nameTextBox"
                              Grid.Row="0"
                              Grid.Column="1"
                              Margin="0,0,0,6"
                              VerticalContentAlignment="Center"
-                             Text="{Binding Name,
-                                            ValidatesOnNotifyDataErrors=True}" />
-
+                             Text="{Binding Name, ValidatesOnNotifyDataErrors=True}" />
                     <Label Grid.Row="1"
                            Grid.Column="0"
                            Margin="0,0,6,6" Content="Assigned To:"/>
-                    <Label Grid.Row="1"
-                             Grid.Column="1"
-                             Margin="0,0,0,6"
-                             Content="@me" />
-
-                    <Label Grid.Row="5"
+                    <Label Grid.Row="2"
+                        Grid.Column="0"
+                        Margin="0,0,6,-26" Content="Created By:"/>
+                    <Label Grid.Row="3"
                            Grid.Column="0"
-                           Margin="0,0,6,6">
-                        Status:
-                    </Label>
-                    <ComboBox Grid.Row="5"
-                              Grid.Column="1"
-                              Margin="0,0,0,6"
+                           Margin="0,31,6,-57" Content="Status:"/>
+                    <ComboBox Grid.Row="1"
+                              Margin="82,0,0,6"
+                              ItemsSource="{Binding AssignedTo}"
+                              SelectedItem="{Binding SelectedAssignedTo}"
+                              Text="{Binding NewAssignedTo, UpdateSourceTrigger=LostFocus}"
+                              Grid.ColumnSpan="2" />
+                    <ComboBox Grid.Row="2"
+                              Margin="82,0,0,-26"
+                              ItemsSource="{Binding CreatedBy}"
+                              SelectedItem="{Binding SelectedCreatedByo}"
+                              Text="{Binding NewCreatedBy, UpdateSourceTrigger=LostFocus}"
+                              Grid.ColumnSpan="2" />
+                    <ComboBox Grid.Row="3"
+                              Margin="82,31,0,-57"
                               ItemTemplate="{StaticResource EnumTemplate}"
                               ItemsSource="{Binding AllReviewStatuses}"
-                              SelectedItem="{Binding ReviewStatus}" />
+                              SelectedItem="{Binding ReviewStatus}" Grid.ColumnSpan="2" />
                 </Grid>
             </StackPanel>
-            <fwc:DialogPanel.ButtonPanel>
-                <fwc:ButtonPanel>
-                    <Button Name="okButton"
-                            Content="OK"
-                            IsDefault="True"
-                            Style="{StaticResource LyncButtonStyle}" />
-                    <Button Style="{StaticResource LyncButtonStyle}" fw:UI.ButtonType="Cancel" />
-                </fwc:ButtonPanel>
-            </fwc:DialogPanel.ButtonPanel>
         </fwc:DialogPanel>
     </AdornerDecorator>
 </Window>


### PR DESCRIPTION
The initial PR implementation is super limited in what kind of PR queries one can write. With this patch we will extend it to allow 'Assigned To' and/or  'Created By' to be set to '@me' or not set (which means, anyone).

The implementation opens the door for future UX around adding specific people / IDs besides '@me'.

Fixes #68 
Fixes #70
