### PR TITLE
Missing PullRequest type

### DIFF
--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Tools.TeamMate.Model
             result.SetAttribute<DateTime>(Schema.Date, entry.Date);
 
             WorkItemReference workItemReference = entry.Key as WorkItemReference;
-            GitPullRequest pullRequestReference = entry.Key as GitPullRequest;
+            PullRequestReference pullRequestReference = entry.Key as PullRequestReference;
             if (workItemReference != null)
             {
                 result.Add(WriteWorkItemReference(workItemReference));
@@ -335,8 +335,8 @@ namespace Microsoft.Tools.TeamMate.Model
             else if (pullRequestReference != null)
             {
                 XElement e = new XElement(Schema.PullRequest);
-                e.SetAttribute<Guid>(Schema.PullRequestProjectId, pullRequestReference.Repository.Id);
-                e.SetAttribute<int>(Schema.PullRequestId, pullRequestReference.PullRequestId);
+                e.SetAttribute<Guid>(Schema.PullRequestProjectId, pullRequestReference.ProjectId);
+                e.SetAttribute<int>(Schema.PullRequestId, pullRequestReference.Id);
                 result.Add(e);
             }
             else

--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -328,10 +328,18 @@ namespace Microsoft.Tools.TeamMate.Model
 
             WorkItemReference workItemReference = entry.Key as WorkItemReference;
             PullRequestReference pullRequestReference = entry.Key as PullRequestReference;
+            GitPullRequest gitPullRequest = entry.Key as GitPullRequest;
             if (workItemReference != null)
             {
                 result.Add(WriteWorkItemReference(workItemReference));
             }
+            else if (gitPullRequest != null)
+            {
+                XElement e = new XElement(Schema.PullRequest);
+                e.SetAttribute<Guid>(Schema.PullRequestProjectId, gitPullRequest.GetReference().ProjectId);
+                e.SetAttribute<int>(Schema.PullRequestId, gitPullRequest.GetReference().Id);
+                result.Add(e);
+           }
             else if (pullRequestReference != null)
             {
                 XElement e = new XElement(Schema.PullRequest);


### PR DESCRIPTION
We have an incorrect type for the pull request in the project context serializer. This change fixes it.

Fix #74 