### PR TITLE
Change the global search shortcut from WIN+Tilde to WIN+END.

### DIFF
--- a/Source/TeamMate/Model/Settings/SettingsSerializer.cs
+++ b/Source/TeamMate/Model/Settings/SettingsSerializer.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Tools.TeamMate.Model.Settings
             settingsElement.ReadElementValue<bool>(Schema.IsTracingEnabled, (value) => settings.IsTracingEnabled = value);
             settingsElement.ReadElementValue<KeyGesture>(Schema.QuickCreateGesture, (value) => settings.QuickCreateGesture = value);
             settingsElement.ReadElementValue<KeyGesture>(Schema.QuickCreateWithOptionsGesture, (value) => settings.QuickCreateWithOptionsGesture = value);
-            settingsElement.ReadElementValue<KeyGesture>(Schema.QuickSearchGesture, (value) => settings.QuickSearchGesture = value);
             settingsElement.ReadElementValue<KeyGesture>(Schema.ToggleMainWindowGesture, (value) => settings.ToggleMainWindowGesture = value);
             settingsElement.ReadElementValue<bool>(Schema.LaunchOnStartup, (value) => settings.LaunchOnStartup = value);
             settingsElement.ReadElementValue<bool>(Schema.ShowSplashScreen, (value) => settings.ShowSplashScreen = value);
@@ -139,7 +138,6 @@ namespace Microsoft.Tools.TeamMate.Model.Settings
             e.SetElementValue<TimeSpan>(Schema.RefreshInterval, settings.RefreshInterval);
             e.SetElementValue<KeyGesture>(Schema.QuickCreateGesture, settings.QuickCreateGesture);
             e.SetElementValue<KeyGesture>(Schema.QuickCreateWithOptionsGesture, settings.QuickCreateWithOptionsGesture);
-            e.SetElementValue<KeyGesture>(Schema.QuickSearchGesture, settings.QuickSearchGesture);
             e.SetElementValue<KeyGesture>(Schema.ToggleMainWindowGesture, settings.ToggleMainWindowGesture);
             e.SetElementValue<bool>(Schema.SearchIdsAutomatically, settings.SearchIdsAutomatically);
             e.SetElementValue<bool>(Schema.ShowCountdown, settings.ShowCountdown);
@@ -273,7 +271,6 @@ namespace Microsoft.Tools.TeamMate.Model.Settings
 
             public static readonly XName QuickCreateGesture = "QuickCreateGesture";
             public static readonly XName QuickCreateWithOptionsGesture = "QuickCreateWithOptionsGesture";
-            public static readonly XName QuickSearchGesture = "QuickSearchGesture";
             public static readonly XName ToggleMainWindowGesture = "ToggleMainWindowGesture";
 
             public static readonly XName RefreshInterval = "RefreshInterval";

--- a/Source/TeamMate/Resources/TeamMateGestures.cs
+++ b/Source/TeamMate/Resources/TeamMateGestures.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Tools.TeamMate.Resources
 
             QuickCreate = new KeyGesture(Key.A, ModifierKeys.Shift | ModifierKeys.Windows);
             QuickCreateWithOptions = new KeyGesture(Key.A, ModifierKeys.Control | ModifierKeys.Windows);
-            QuickSearch = new KeyGesture(Key.OemTilde, ModifierKeys.Windows);
-            ToggleMainWindow = new KeyGesture(Key.Escape, ModifierKeys.Windows);
+            QuickSearch = new KeyGesture(Key.End, ModifierKeys.Windows);
+            ToggleMainWindow = new KeyGesture(Key.F, ModifierKeys.Windows);
 
             New = new KeyGesture(Key.N, ModifierKeys.Control);
             Minimize = new KeyGesture(Key.Escape);

--- a/Source/TeamMate/Windows/WelcomeDialog.xaml
+++ b/Source/TeamMate/Windows/WelcomeDialog.xaml
@@ -19,7 +19,7 @@
             <TextBlock Margin="0,12,0,0" FontSize="20" Text="Keyboard shortcuts"/>
             <TextBlock Margin="0,12" Foreground="{StaticResource ApplicationColorBrush}">You might want to learn these, you'll use them all the time.</TextBlock>
             <TextBlock>
-                <Run>•</Run> <Run FontWeight="Bold">WIN + `</Run> <Run>(grave accent, above the Tab key), opens the quick search dialog.</Run>
+                <Run>•</Run> <Run FontWeight="Bold">WIN + END</Run> <Run>opens the quick search dialog.</Run>
                 <LineBreak />
                 <Run>•</Run> <Run FontWeight="Bold">SHIFT + WIN + A</Run> <Run>creates a new default work item.</Run>
                 <LineBreak />


### PR DESCRIPTION
In order to do so, we need to stop persisting the hard-coded setting as well.

Fixes issue #86 