### PR TITLE
Allow for PR queries across projects

### DIFF
--- a/Source/TeamFoundation.WebApi/HyperlinkFactory.cs
+++ b/Source/TeamFoundation.WebApi/HyperlinkFactory.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Tools.TeamMate.TeamFoundation.WebApi
             return builder.Uri;
         }
 
-        public Uri GetPullRequestUrl(int id, string repositoryName)
+        public Uri GetPullRequestUrl(int id, string projectName, string repositoryName)
         {
             UriBuilder builder = new UriBuilder(this.BaseUrl);
-            builder.Path = CombinePath(builder.Path, ProjectName, "_git", repositoryName, "pullrequest", id.ToString());
+            builder.Path = CombinePath(builder.Path, projectName, "_git", repositoryName, "pullrequest", id.ToString());
             return builder.Uri;
         }
 

--- a/Source/TeamMate/Controls/GlobalCommandBar.xaml
+++ b/Source/TeamMate/Controls/GlobalCommandBar.xaml
@@ -38,7 +38,7 @@
                     Visibility="{Binding ElementName=self,
                                          Path=Type,
                                          Converter={x:Static fw:Converters.Visibility},
-                                         ConverterParameter={x:Static vm:CommandBarType.CodeReviews}}">
+                                         ConverterParameter={x:Static vm:CommandBarType.PullRequests}}">
             <Button Command="{x:Static tmr:TeamMateCommands.Refresh}" Style="{StaticResource CommandAppBarButtonStyle}" />
             <Button Command="{x:Static tmr:TeamMateCommands.MarkAllAsRead}" Style="{StaticResource CommandAppBarButtonStyle}" />
         </StackPanel>

--- a/Source/TeamMate/Model/ProjectContext.cs
+++ b/Source/TeamMate/Model/ProjectContext.cs
@@ -8,6 +8,9 @@ using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Services.Graph.Client;
+using Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi;
 
 namespace Microsoft.Tools.TeamMate.Model
 {
@@ -35,6 +38,12 @@ namespace Microsoft.Tools.TeamMate.Model
         public Microsoft.VisualStudio.Services.Identity.Identity Identity { get; set; }
 
         public WorkItemTrackingBatchHttpClient WorkItemTrackingBatchClient { get; set; }
+
+        public GraphHttpClient GraphClient { get; set; }
+
+        public MemberEntitlementManagementHttpClient MemberEntitlementManagementClient { get; set; }
+
+        public Task<List<GraphUser>> UsersAsync { get; set; }
 
         public string ProjectName { get; set; }
 

--- a/Source/TeamMate/Model/ProjectContext.cs
+++ b/Source/TeamMate/Model/ProjectContext.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Services.Graph.Client;
-using Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi;
 
 namespace Microsoft.Tools.TeamMate.Model
 {
@@ -40,8 +39,6 @@ namespace Microsoft.Tools.TeamMate.Model
         public WorkItemTrackingBatchHttpClient WorkItemTrackingBatchClient { get; set; }
 
         public GraphHttpClient GraphClient { get; set; }
-
-        public MemberEntitlementManagementHttpClient MemberEntitlementManagementClient { get; set; }
 
         public Task<List<GraphUser>> UsersAsync { get; set; }
 

--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Tools.TeamMate.Model
             query.ReviewStatus = e.GetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus);
             query.AssignedTo = e.GetAttribute<string>(Schema.AssignedTo);
             query.CreatedBy = e.GetAttribute<string>(Schema.CreatedBy);
+            query.Project = e.GetAttribute<string>(Schema.PullRequestProject);
 
             return query;
         }
@@ -145,6 +146,7 @@ namespace Microsoft.Tools.TeamMate.Model
             e.SetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus, query.ReviewStatus);
             e.SetAttribute<string>(Schema.CreatedBy, query.CreatedBy);
             e.SetAttribute<string>(Schema.AssignedTo, query.AssignedTo);
+            e.SetAttribute<string>(Schema.PullRequestProject, query.Project);
 
             return e;
         }
@@ -421,6 +423,7 @@ namespace Microsoft.Tools.TeamMate.Model
             public static readonly XName PullRequest = "PullRequest";
             public const string PullRequestId = "PullRequestId";
             public const string PullRequestProjectId = "PullRequestProjectId";
+            public const string PullRequestProject = "PullRequestProject";
 
             // ProjectSettings Stuff
             public static readonly XName ProjectSettings = "ProjectSettings";

--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Tools.TeamMate.Model
             query.AssignedTo = e.GetAttribute<Guid?>(Schema.AssignedTo);
             query.CreatedBy = e.GetAttribute<Guid?>(Schema.CreatedBy);
             query.Project = e.GetAttribute<string>(Schema.PullRequestProject);
+            query.UIAssignedTo = e.GetAttribute<string>(Schema.UIAssignedTo);
+            query.UICreatedBy = e.GetAttribute<string>(Schema.UICreatedBy);
 
             return query;
         }
@@ -146,6 +148,8 @@ namespace Microsoft.Tools.TeamMate.Model
             e.SetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus, query.ReviewStatus);
             e.SetAttribute<Guid?>(Schema.CreatedBy, query.CreatedBy);
             e.SetAttribute<Guid?>(Schema.AssignedTo, query.AssignedTo);
+            e.SetAttribute<string>(Schema.UICreatedBy, query.UICreatedBy);
+            e.SetAttribute<string>(Schema.UIAssignedTo, query.UIAssignedTo);
             e.SetAttribute<string>(Schema.PullRequestProject, query.Project);
 
             return e;
@@ -387,6 +391,8 @@ namespace Microsoft.Tools.TeamMate.Model
             public const string State = "State";
             public const string Title = "Title";
             public const string Revision = "Revision";
+            public const string UIAssignedTo = "UIAssignedTo";
+            public const string UICreatedBy = "UICreatedBy";
 
             public static XName RecentItems = "RecentItems";
             public static XName RecentlyViewedWorkItems = "RecentlyViewedWorkItems";

--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -75,8 +75,8 @@ namespace Microsoft.Tools.TeamMate.Model
 
             query.Name = e.GetAttribute<string>(Schema.Name);
             query.ReviewStatus = e.GetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus);
-            query.AssignedTo = e.GetAttribute<string>(Schema.AssignedTo);
-            query.CreatedBy = e.GetAttribute<string>(Schema.CreatedBy);
+            query.AssignedTo = e.GetAttribute<Guid?>(Schema.AssignedTo);
+            query.CreatedBy = e.GetAttribute<Guid?>(Schema.CreatedBy);
             query.Project = e.GetAttribute<string>(Schema.PullRequestProject);
 
             return query;
@@ -144,8 +144,8 @@ namespace Microsoft.Tools.TeamMate.Model
             XElement e = new XElement(Schema.PullRequestQueryInfo);
             e.SetAttribute<string>(Schema.Name, query.Name);
             e.SetAttribute<PullRequestQueryReviewStatus>(Schema.ReviewStatus, query.ReviewStatus);
-            e.SetAttribute<string>(Schema.CreatedBy, query.CreatedBy);
-            e.SetAttribute<string>(Schema.AssignedTo, query.AssignedTo);
+            e.SetAttribute<Guid?>(Schema.CreatedBy, query.CreatedBy);
+            e.SetAttribute<Guid?>(Schema.AssignedTo, query.AssignedTo);
             e.SetAttribute<string>(Schema.PullRequestProject, query.Project);
 
             return e;

--- a/Source/TeamMate/Model/PullRequestQueryInfo.cs
+++ b/Source/TeamMate/Model/PullRequestQueryInfo.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Tools.TeamMate.Model
 
         public string Name { get; set; }
         public PullRequestQueryReviewStatus ReviewStatus { get; set; }
-        public string CreatedBy { get; set; }
+        public Guid? CreatedBy { get; set; }
 
-        public string AssignedTo { get; set; }
+        public Guid? AssignedTo { get; set; }
 
         public string Project { get; set; }
     }

--- a/Source/TeamMate/Model/PullRequestQueryInfo.cs
+++ b/Source/TeamMate/Model/PullRequestQueryInfo.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Tools.TeamMate.Model
 
         public Guid? AssignedTo { get; set; }
 
-        public string SelectedCreatedBy { get; set; }
+        public string UICreatedBy { get; set; }
 
-        public string SelectedAssignedTo { get; set; }
+        public string UIAssignedTo { get; set; }
 
         public string Project { get; set; }
     }

--- a/Source/TeamMate/Model/PullRequestQueryInfo.cs
+++ b/Source/TeamMate/Model/PullRequestQueryInfo.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Tools.TeamMate.Model
         public string CreatedBy { get; set; }
 
         public string AssignedTo { get; set; }
+
+        public string Project { get; set; }
     }
     public enum PullRequestQueryReviewStatus
     {

--- a/Source/TeamMate/Model/PullRequestQueryInfo.cs
+++ b/Source/TeamMate/Model/PullRequestQueryInfo.cs
@@ -20,6 +20,10 @@ namespace Microsoft.Tools.TeamMate.Model
 
         public Guid? AssignedTo { get; set; }
 
+        public string SelectedCreatedBy { get; set; }
+
+        public string SelectedAssignedTo { get; set; }
+
         public string Project { get; set; }
     }
     public enum PullRequestQueryReviewStatus

--- a/Source/TeamMate/Services/ResolverService.cs
+++ b/Source/TeamMate/Services/ResolverService.cs
@@ -1,0 +1,165 @@
+﻿using Microsoft.Tools.TeamMate.Model;
+using Microsoft.VisualStudio.Services.Graph.Client;
+using Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Tools.TeamMate.Services
+{
+    public class ResolverService
+    {
+        private List<GraphUser> GraphUserCache { get; set; }
+
+        private List<GraphGroup> GraphGroupCache { get; set; }
+
+        private List<GroupEntitlement> GroupEntitlements { get; set; }
+
+        private List<Task> Tasks = new List<Task>();
+
+        private async Task<List<GraphUser>> FetchUsersAsync(
+            GraphHttpClient graphClient,
+            MemberEntitlementManagementHttpClient memberEntitlementManagementClient)
+        {
+            if (GraphUserCache != null)
+            {
+                return GraphUserCache;
+            }
+
+            List<GraphUser> users = new List<GraphUser>();
+
+            string continuationToken = null;
+            do
+            {
+                var data = await graphClient.ListUsersAsync(null, continuationToken);
+                continuationToken = data.ContinuationToken != null ? data.ContinuationToken.First() : null;
+                foreach (var user in data.GraphUsers)
+                {
+                    users.Add(user);
+                }
+            }
+            while (continuationToken != null);
+
+            GraphUserCache = users;
+
+            return users;
+        }
+
+        private async Task<List<GraphGroup>> FetchGroupsAsync(
+            GraphHttpClient graphClient)
+        {
+            if (GraphGroupCache != null)
+            {
+                return GraphGroupCache;
+            }
+
+            List<GraphGroup> groups = new List<GraphGroup>();
+
+            string continuationToken = null;
+            do
+            {
+                // ListGroupsAsync
+                var data = await graphClient.ListGroupsAsync(null, null, continuationToken);
+                continuationToken = data.ContinuationToken != null ? data.ContinuationToken.First() : null;
+                foreach (var group in data.GraphGroups)
+                {
+                    groups.Add(group);
+                }
+            }
+            while (continuationToken != null);
+
+            GraphGroupCache = groups;
+
+            return groups;
+        }
+
+        private async Task<List<GroupEntitlement>> FetchGroupsEntitlementsAsync(
+          MemberEntitlementManagementHttpClient memberEntitlementManagementClient)
+        {
+            if (GroupEntitlements != null)
+            {
+                return GroupEntitlements;
+            }
+
+            GroupEntitlements = await memberEntitlementManagementClient.GetGroupEntitlementsAsync();
+           
+            return GroupEntitlements;
+        }
+
+        public async void FetchDataSync(
+            GraphHttpClient client,
+            MemberEntitlementManagementHttpClient memberEntitlementManagementClient)
+        {
+            Tasks.Add(FetchUsersAsync(client, memberEntitlementManagementClient));
+            Tasks.Add(FetchGroupsAsync(client));
+
+            // TODO(MEM)
+          // Tasks.Add(FetchGroupsEntitlementsAsync(memberEntitlementManagementClient));
+        }
+
+        public ObservableCollection<string> GetDisplayNames()
+        {
+            foreach (var task in Tasks)
+            {
+                task.Wait();
+            }
+
+            ObservableCollection<string> strings = new ObservableCollection<string>();
+
+            foreach (var user in GraphUserCache)
+            {
+                strings.Add(user.DisplayName);
+            }
+
+            foreach (var user in GraphGroupCache)
+            {
+                strings.Add(user.DisplayName);
+            }
+
+            return strings;
+        }
+
+        public async Task<string> Resolve(
+            GraphHttpClient client,
+            MemberEntitlementManagementHttpClient memberEntitlementManagementClient,
+            string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            foreach (var task in Tasks)
+            {
+                task.Wait();
+            }
+
+            foreach (var user in GraphUserCache)
+            {
+                if (user.MailAddress != null &&
+                    (user.MailAddress.StartsWith(value)))
+                {
+                    var storageKey = client.GetStorageKeyAsync(user.Descriptor).Result;
+
+                    // TODO(MEM)
+                    return "{" + storageKey.Value.ToString() + "}";
+                }
+            }
+
+            foreach (var group in GraphGroupCache)
+            {
+                if (group.MailAddress != null &&
+                    (group.MailAddress.Contains(value)))
+                {
+                    var storageKey = client.GetStorageKeyAsync(group.Descriptor).Result;
+
+                    // TODO(MEM)
+                    return "{" + storageKey.Value.ToString() + "}";
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/TeamMate/Services/ResolverService.cs
+++ b/Source/TeamMate/Services/ResolverService.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Tools.TeamMate.Services
             return groups;
         }
 
-        public async void FetchDataSync(
+        public void FetchDataSync(
             GraphHttpClient client)
         {
             Tasks.Add(FetchUsersAsync(client));

--- a/Source/TeamMate/Services/ResolverService.cs
+++ b/Source/TeamMate/Services/ResolverService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Controls;
 
 namespace Microsoft.Tools.TeamMate.Services
 {
@@ -77,36 +78,6 @@ namespace Microsoft.Tools.TeamMate.Services
             Tasks.Add(FetchGroupsAsync(client));
         }
 
-        public void WaitToComplete()
-        {
-            foreach (var task in Tasks)
-            {
-                task.Wait();
-            }
-        }
-
-        public ObservableCollection<string> GetDisplayNames()
-        {
-            foreach (var task in Tasks)
-            {
-                task.Wait();
-            }
-
-            ObservableCollection<string> strings = new ObservableCollection<string>();
-
-            foreach (var user in GraphUserCache)
-            {
-                strings.Add(user.DisplayName);
-            }
-
-            foreach (var user in GraphGroupCache)
-            {
-                strings.Add(user.DisplayName);
-            }
-
-            return strings;
-        }
-
         public async Task<Guid?> Resolve(
             GraphHttpClient client,
             string value)
@@ -115,6 +86,8 @@ namespace Microsoft.Tools.TeamMate.Services
             {
                 return null;
             }
+
+            await Task.Run(() => { foreach (var task in this.Tasks) { task.Wait(); } });
 
             foreach (var user in GraphUserCache)
             {

--- a/Source/TeamMate/Services/VstsConnectionService.cs
+++ b/Source/TeamMate/Services/VstsConnectionService.cs
@@ -19,6 +19,8 @@ using System.Threading.Tasks;
 using ProjectHttpClient = Microsoft.TeamFoundation.Core.WebApi.ProjectHttpClient;
 using WorkItemField = Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItemField;
 using WorkItemType = Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItemType;
+using Microsoft.VisualStudio.Services.Graph.Client;
+using Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi;
 
 namespace Microsoft.Tools.TeamMate.Services
 {
@@ -35,6 +37,10 @@ namespace Microsoft.Tools.TeamMate.Services
 
         [Import]
         public WindowService WindowService { get; set; }
+    
+        [Import]
+        public ResolverService ResolverService { get; set; }
+
 
         private async Task<VssConnection> ConnectAsync(Uri projectCollectionUri, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -137,6 +143,8 @@ namespace Microsoft.Tools.TeamMate.Services
                 WorkItemTrackingBatchHttpClient batchWitClient = connection.GetClient<WorkItemTrackingBatchHttpClient>();
                 ProjectHttpClient projectClient = connection.GetClient<ProjectHttpClient>();
                 GitHttpClient gitClient = connection.GetClient<GitHttpClient>();
+                GraphHttpClient graphClient = connection.GetClient<GraphHttpClient>();
+                MemberEntitlementManagementHttpClient memberEntitlementManagementClient = connection.GetClient<MemberEntitlementManagementHttpClient>();
 
                 var projectId = projectInfo.Reference.ProjectId;
 
@@ -174,6 +182,7 @@ namespace Microsoft.Tools.TeamMate.Services
                 projectContext.WorkItemTrackingClient = witClient;
                 projectContext.WorkItemTrackingBatchClient = batchWitClient;
                 projectContext.GitHttpClient = gitClient;
+                projectContext.GraphClient = graphClient;
                 projectContext.WorkItemTypes = workItemTypeInfos;
                 projectContext.ProjectInfo = projectInfo;
                 projectContext.Identity = identity;
@@ -182,6 +191,11 @@ namespace Microsoft.Tools.TeamMate.Services
                 projectContext.WorkItemFields = fields;
                 projectContext.WorkItemFieldsByName = fields.ToDictionary(f => f.ReferenceName, StringComparer.OrdinalIgnoreCase);
                 projectContext.RequiredWorkItemFieldNames = GetWorkItemFieldsToPrefetch(projectContext.WorkItemFieldsByName);
+                projectContext.MemberEntitlementManagementClient = memberEntitlementManagementClient;
+
+                this.ResolverService.FetchDataSync(
+                   graphClient,
+                   memberEntitlementManagementClient);
 
                 return projectContext;
             }
@@ -207,7 +221,6 @@ namespace Microsoft.Tools.TeamMate.Services
 
             return null;
         }
-
         public ICollection<string> GetWorkItemFieldsToPrefetch(IDictionary<string, WorkItemField> availableFields)
         {
             // Prefetch the fields that are interesting to our services or object model...

--- a/Source/TeamMate/Services/VstsConnectionService.cs
+++ b/Source/TeamMate/Services/VstsConnectionService.cs
@@ -20,7 +20,6 @@ using ProjectHttpClient = Microsoft.TeamFoundation.Core.WebApi.ProjectHttpClient
 using WorkItemField = Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItemField;
 using WorkItemType = Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItemType;
 using Microsoft.VisualStudio.Services.Graph.Client;
-using Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi;
 
 namespace Microsoft.Tools.TeamMate.Services
 {
@@ -144,7 +143,6 @@ namespace Microsoft.Tools.TeamMate.Services
                 ProjectHttpClient projectClient = connection.GetClient<ProjectHttpClient>();
                 GitHttpClient gitClient = connection.GetClient<GitHttpClient>();
                 GraphHttpClient graphClient = connection.GetClient<GraphHttpClient>();
-                MemberEntitlementManagementHttpClient memberEntitlementManagementClient = connection.GetClient<MemberEntitlementManagementHttpClient>();
 
                 var projectId = projectInfo.Reference.ProjectId;
 
@@ -191,11 +189,9 @@ namespace Microsoft.Tools.TeamMate.Services
                 projectContext.WorkItemFields = fields;
                 projectContext.WorkItemFieldsByName = fields.ToDictionary(f => f.ReferenceName, StringComparer.OrdinalIgnoreCase);
                 projectContext.RequiredWorkItemFieldNames = GetWorkItemFieldsToPrefetch(projectContext.WorkItemFieldsByName);
-                projectContext.MemberEntitlementManagementClient = memberEntitlementManagementClient;
 
                 this.ResolverService.FetchDataSync(
-                   graphClient,
-                   memberEntitlementManagementClient);
+                   graphClient);
 
                 return projectContext;
             }

--- a/Source/TeamMate/Services/WindowService.cs
+++ b/Source/TeamMate/Services/WindowService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Tools.TeamMate.Foundation.Shell;
+﻿using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Microsoft.Tools.TeamMate.Foundation.Shell;
 using Microsoft.Tools.TeamMate.Foundation.Threading;
 using Microsoft.Tools.TeamMate.Foundation.Windows;
 using Microsoft.Tools.TeamMate.Foundation.Windows.Controls;
@@ -298,6 +299,12 @@ namespace Microsoft.Tools.TeamMate.Services
             viewModel.QueryInfo = queryInfo;
             dialog.DataContext = viewModel;
             dialog.Owner = View.GetWindow(ownerViewModel);
+
+            var projects = this.SettingsService.Settings.Projects;
+            foreach (var project in projects)
+            {
+                viewModel.AddProject(project.ProjectName);
+            }
 
             return (dialog.ShowDialog() == true) ? viewModel.QueryInfo : null;
         }

--- a/Source/TeamMate/Services/WindowService.cs
+++ b/Source/TeamMate/Services/WindowService.cs
@@ -388,7 +388,6 @@ namespace Microsoft.Tools.TeamMate.Services
             this.MainWindowViewModel.Search(e.SearchText, true, true);
         }
 
-
         public bool RequestShutdown()
         {
             bool shouldCancel = this.PromptSaveOnDirtyWindows();

--- a/Source/TeamMate/Services/WindowService.cs
+++ b/Source/TeamMate/Services/WindowService.cs
@@ -300,13 +300,6 @@ namespace Microsoft.Tools.TeamMate.Services
             dialog.DataContext = viewModel;
             dialog.Owner = View.GetWindow(ownerViewModel);
 
-            // TODO(MEM)
-            var projects = this.SettingsService.Settings.Projects;
-            foreach (var project in projects)
-            {
-                viewModel.AddProject(project.ProjectName);
-            }
-
             return (dialog.ShowDialog() == true) ? viewModel.QueryInfo : null;
         }
 

--- a/Source/TeamMate/Services/WindowService.cs
+++ b/Source/TeamMate/Services/WindowService.cs
@@ -300,6 +300,7 @@ namespace Microsoft.Tools.TeamMate.Services
             dialog.DataContext = viewModel;
             dialog.Owner = View.GetWindow(ownerViewModel);
 
+            // TODO(MEM)
             var projects = this.SettingsService.Settings.Projects;
             foreach (var project in projects)
             {

--- a/Source/TeamMate/TeamMate.csproj
+++ b/Source/TeamMate/TeamMate.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Services\AsyncWriterService.cs" />
     <Compile Include="Services\ExternalWebBrowserService.cs" />
     <Compile Include="Services\GlobalCommandService.cs" />
+    <Compile Include="Services\ResolverService.cs" />
     <Compile Include="Services\HistoryService.cs" />
     <Compile Include="Services\SearchService.cs" />
     <Compile Include="Services\SessionService.cs" />
@@ -998,6 +999,9 @@
       <Version>5.8.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi">
+      <Version>16.205.1</Version>
     </PackageReference>
     <PackageReference Include="SimpleInjector">
       <Version>5.3.3</Version>

--- a/Source/TeamMate/TeamMate.csproj
+++ b/Source/TeamMate/TeamMate.csproj
@@ -1000,9 +1000,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Services.MemberEntitlementManagement.WebApi">
-      <Version>16.205.1</Version>
-    </PackageReference>
     <PackageReference Include="SimpleInjector">
       <Version>5.3.3</Version>
     </PackageReference>

--- a/Source/TeamMate/ViewModels/PageViewModelBase.cs
+++ b/Source/TeamMate/ViewModels/PageViewModelBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         None,
         Home,
         WorkItems,
-        CodeReviews,
+        PullRequests,
         Projects
     }
 }

--- a/Source/TeamMate/ViewModels/ProjectPickerDialogViewModel.cs
+++ b/Source/TeamMate/ViewModels/ProjectPickerDialogViewModel.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             get { return this.selectedProjects; }
             set { this.SetProperty(ref this.selectedProjects, value); }
         }
-
         public void CancelConnect()
         {
             this.previousCancellationTokenSource.Cancel();

--- a/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             model.Filters.Add(new ListViewFilter("Pending", (o) => ((PullRequestRowViewModel)o).IsPending));
             model.Filters.Add(new ListViewFilter("Waiting", (o) => ((PullRequestRowViewModel)o).IsWaiting));
             model.Filters.Add(new ListViewFilter("Signed Off", (o) => ((PullRequestRowViewModel)o).IsSignedOff));
-            model.Filters.Add(new ListViewFilter("Not Signed Off By Me", (o) => !((PullRequestRowViewModel)o).IsSignedOffByMe));
+            model.Filters.Add(new ListViewFilter("Not Signed Off / Declined By Me", (o) => !((PullRequestRowViewModel)o).IsSignedOffOrDeclinedByMe));
             model.Filters.Add(new ListViewFilter("Completed", (o) => ((PullRequestRowViewModel)o).IsCompleted));
 
             model.Fields.Add(ListFieldInfo.Create<string>("CreatedBy", "Created By"));

--- a/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
         public PullRequestPageViewModel()
         {
-            this.CommandBarType = CommandBarType.CodeReviews;
+            this.CommandBarType = CommandBarType.PullRequests;
             this.modelList = new List<PullRequestRowViewModel>();
             this.collectionView = new ListCollectionView(this.modelList);
 

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 
 namespace Microsoft.Tools.TeamMate.ViewModels
 {
@@ -121,8 +122,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             {
                 this.Name = this.queryInfo.Name;
                 this.ReviewStatus = this.queryInfo.ReviewStatus;
-                this.AssignedTo = null;
-                this.CreatedBy = null;
+                this.AssignedTo = this.queryInfo.SelectedAssignedTo;
+                this.CreatedBy = this.queryInfo.SelectedAssignedTo;
             }
         }
 
@@ -133,14 +134,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.queryInfo.Name = this.Name.Trim();
                 this.queryInfo.ReviewStatus = this.ReviewStatus;
                 this.queryInfo.Project = this.SelectedProject.Trim();
-
-                this.ResolverService.Resolve(
-                    this.SessionService.Session.ProjectContext.GraphClient,
-                    this.AssignedTo).ContinueWith(assignedTo => this.queryInfo.AssignedTo);
-
-                this.ResolverService.Resolve(
-                    this.SessionService.Session.ProjectContext.GraphClient,
-                    this.CreatedBy).ContinueWith(createdBy => this.queryInfo.CreatedBy);
+                this.queryInfo.SelectedAssignedTo = this.AssignedTo;
+                this.queryInfo.SelectedCreatedBy = this.CreatedBy;
             }
         }
 

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         private PullRequestQueryInfo queryInfo;
         private PullRequestQueryReviewStatus reviewStatus;
 
+        private string _selectedProject;
+        private ObservableCollection<string> _project = new ObservableCollection<string>()
+        {
+        };
+
         private string _selectedAssignedTo;
         private ObservableCollection<string> _assignedTo = new ObservableCollection<string>()
         {
@@ -71,7 +76,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 OnPropertyChanged("SelectedAssignedTo");
             }
         }
-
+       
         public string NewAssignedTo
         {
             set
@@ -85,6 +90,35 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 {
                     this._assignedTo.Add(value);
                     SelectedAssignedTo = value;
+                }
+            }
+        }
+        public IEnumerable Project
+        {
+            get { return this._project; }
+        }
+        public string SelectedProject
+        {
+            get { return this._selectedProject; }
+            set
+            {
+                this._selectedProject = value;
+                OnPropertyChanged("SelectedProject");
+            }
+        }
+        public string NewProject
+        {
+            set
+            {
+                if (SelectedProject != null)
+                {
+                    return;
+                }
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    this._project.Add(value);
+                    SelectedProject = value;
                 }
             }
         }
@@ -127,6 +161,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.ReviewStatus = this.queryInfo.ReviewStatus;
                 this.SelectedAssignedTo = this.queryInfo.AssignedTo;
                 this.SelectedCreatedBy = this.queryInfo.CreatedBy;
+                this.SelectedProject = this.queryInfo.Project;
             }
         }
 
@@ -138,6 +173,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.queryInfo.ReviewStatus = this.ReviewStatus;
                 this.queryInfo.AssignedTo = this.SelectedAssignedTo;
                 this.queryInfo.CreatedBy = this.SelectedCreatedBy;
+                this.queryInfo.Project = this.SelectedProject;
             }
         }
 

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 
 namespace Microsoft.Tools.TeamMate.ViewModels
 {
@@ -31,6 +32,9 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
         [Import]
         public SessionService SessionService { get; set; }
+
+        [Import]
+        public SettingsService SettingsService { get; set; }
 
         public PullRequestPickerViewModel()
         {
@@ -124,6 +128,12 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.ReviewStatus = this.queryInfo.ReviewStatus;
                 this.AssignedTo = this.queryInfo.SelectedAssignedTo;
                 this.CreatedBy = this.queryInfo.SelectedAssignedTo;
+            }
+
+            var projects = this.SettingsService.Settings.Projects;
+            foreach (var project in projects)
+            {
+                AddProject(project.ProjectName);
             }
         }
 

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -2,10 +2,13 @@
 using Microsoft.Tools.TeamMate.Foundation.Validation;
 using Microsoft.Tools.TeamMate.Foundation.Windows.MVVM;
 using Microsoft.Tools.TeamMate.Model;
+using Microsoft.Tools.TeamMate.Services;
 using System;
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
 using System.Linq;
+using static Microsoft.TeamFoundation.Client.CommandLine.Options;
 
 namespace Microsoft.Tools.TeamMate.ViewModels
 {
@@ -96,6 +99,10 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         public IEnumerable Project
         {
             get { return this._project; }
+        }
+        public void AddProject(string projectName)
+        {
+            this._project.Add(projectName);
         }
         public string SelectedProject
         {

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -71,13 +71,13 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             get { return this.reviewStatus; }
             set { SetProperty(ref this.reviewStatus, value); }
         }
-        public string AssignedTo
+        public string UIAssignedTo
         {
             get { return this.assignedTo; }
             set { SetProperty(ref this.assignedTo, value); }
         }
 
-        public string CreatedBy
+        public string UICreatedBy
         {
             get { return this.createdBy; }
             set { SetProperty(ref this.createdBy, value); }
@@ -123,8 +123,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             {
                 this.Name = this.queryInfo.Name;
                 this.ReviewStatus = this.queryInfo.ReviewStatus;
-                this.AssignedTo = this.queryInfo.SelectedAssignedTo;
-                this.CreatedBy = this.queryInfo.SelectedAssignedTo;
+                this.UIAssignedTo = this.queryInfo.UIAssignedTo;
+                this.UICreatedBy = this.queryInfo.UICreatedBy;
             }
 
             var projects = this.SettingsService.Settings.Projects;
@@ -144,8 +144,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.queryInfo.Name = this.Name.Trim();
                 this.queryInfo.ReviewStatus = this.ReviewStatus;
                 this.queryInfo.Project = this.SelectedProject.Trim();
-                this.queryInfo.SelectedAssignedTo = this.AssignedTo;
-                this.queryInfo.SelectedCreatedBy = this.CreatedBy;
+                this.queryInfo.UIAssignedTo = this.UIAssignedTo;
+                this.queryInfo.UICreatedBy = this.UICreatedBy;
             }
         }
 

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 
@@ -40,6 +41,10 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         {
             Validator
                 .RuleForProperty(() => Name)
+                    .IsNotEmpty();
+
+            Validator
+                .RuleForProperty(() => SelectedProject)
                     .IsNotEmpty();
         }
 
@@ -112,14 +117,6 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             }
         }
 
-        private TaskContext progress = TaskContext.None;
-
-        public TaskContext Progress
-        {
-            get { return this.progress; }
-            set { this.SetProperty(ref this.progress, value); }
-        }
-
         private void Invalidate()
         {
             if (this.queryInfo != null)
@@ -131,13 +128,16 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             }
 
             var projects = this.SettingsService.Settings.Projects;
-            foreach (var project in projects)
+            if (projects.Count > 0)
             {
-                AddProject(project.ProjectName);
+                foreach (var project in projects)
+                {
+                    AddProject(project.ProjectName);
+                }
             }
         }
 
-        public async void Flush()
+        public void Flush()
         {
             if (this.queryInfo != null)
             {

--- a/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
@@ -180,11 +180,11 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             {
                 query.GitPullRequestSearchCriteria.ReviewerId = this.queryInfo.AssignedTo.Value;
             }
-            else if (this.queryInfo.SelectedAssignedTo != null)
+            else if (this.queryInfo.UIAssignedTo != null)
             {
                 query.GitPullRequestSearchCriteria.ReviewerId = await this.ResolverService.Resolve(
                     this.SessionService.Session.ProjectContext.GraphClient,
-                    this.queryInfo.SelectedAssignedTo);
+                    this.queryInfo.UIAssignedTo);
 
                 this.queryInfo.AssignedTo = query.GitPullRequestSearchCriteria.ReviewerId;
             }
@@ -193,11 +193,11 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             {
                 query.GitPullRequestSearchCriteria.CreatorId = this.queryInfo.CreatedBy.Value;
             }
-            else if (this.queryInfo.CreatedBy != null)
+            else if (this.queryInfo.UICreatedBy != null)
             {
                 query.GitPullRequestSearchCriteria.CreatorId = await this.ResolverService.Resolve(
                     this.SessionService.Session.ProjectContext.GraphClient,
-                    this.queryInfo.SelectedCreatedBy);
+                    this.queryInfo.UICreatedBy);
 
                 this.queryInfo.CreatedBy = query.GitPullRequestSearchCriteria.CreatorId;
             }

--- a/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
@@ -202,6 +202,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 query.GitPullRequestSearchCriteria.ReviewerId = await this.ResolverService.Resolve(
                     this.SessionService.Session.ProjectContext.GraphClient,
                     this.queryInfo.SelectedAssignedTo);
+
+                this.queryInfo.AssignedTo = query.GitPullRequestSearchCriteria.ReviewerId;
             }
 
             if (this.queryInfo.CreatedBy.HasValue)
@@ -213,6 +215,8 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 query.GitPullRequestSearchCriteria.CreatorId = await this.ResolverService.Resolve(
                     this.SessionService.Session.ProjectContext.GraphClient,
                     this.queryInfo.SelectedCreatedBy);
+
+                this.queryInfo.CreatedBy = query.GitPullRequestSearchCriteria.CreatorId;
             }
 
             return query;

--- a/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                         List<Task> tasks = new List<Task>();
 
                         var queryAsyncTask = projectContext.GitHttpClient.GetPullRequestsByProjectAsync(
-                            projectContext.ProjectInfo.ProjectName,
+                            query.ProjectName,
                             query.GitPullRequestSearchCriteria);
 
                         tasks.Add(queryAsyncTask);
@@ -115,6 +115,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
                             pullRequest.Url = projectContext.HyperlinkFactory.GetPullRequestUrl(
                                 pullRequest.Reference.PullRequestId,
+                                query.ProjectName,
                                 pullRequest.Reference.Repository.Name);
                         }
 
@@ -156,7 +157,16 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             var pc = this.SessionService.Session.ProjectContext;
           
             var query = new PullRequestQuery();
-            query.ProjectName = pc.ProjectName;
+
+            if (this.queryInfo.Project != null)
+            {
+                query.ProjectName = this.queryInfo.Project;
+            }
+            else
+            {
+                query.ProjectName = pc.ProjectName;
+            }
+
             query.GitPullRequestSearchCriteria = new GitPullRequestSearchCriteria
             {
                 Status = PullRequestQueryInfo.ReviewStatusesMap[this.queryInfo.ReviewStatus],
@@ -225,7 +235,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             PullRequestRowViewModel viewModel = ViewModelFactory.Create<PullRequestRowViewModel>();
             viewModel.IdentityRef = projectContext.Identity.Id.ToString();
             viewModel.Reference = gitPullRequest;
-            viewModel.ProjectName = projectContext.ProjectName;
+            viewModel.ProjectName = gitPullRequest.Repository.Name;
             return viewModel;
         }
     }

--- a/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
@@ -192,22 +192,14 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
             // TODO(MEM): Mapping
 
-            if (this.queryInfo.AssignedTo == "@me")
+            if (this.queryInfo.AssignedTo.HasValue)
             {
-                query.GitPullRequestSearchCriteria.ReviewerId = pc.Identity.Id;
-            }
-            else if (this.queryInfo.AssignedTo != null)
-            {
-                query.GitPullRequestSearchCriteria.ReviewerId = new Guid(this.queryInfo.AssignedTo);
+                query.GitPullRequestSearchCriteria.ReviewerId = this.queryInfo.AssignedTo.Value;
             }
 
-            if (this.queryInfo.CreatedBy == "@me")
+            if (this.queryInfo.CreatedBy.HasValue)
             {
-                query.GitPullRequestSearchCriteria.CreatorId = pc.Identity.Id;
-            }
-            else if (this.queryInfo.CreatedBy != null)
-            {
-                query.GitPullRequestSearchCriteria.CreatorId = new Guid(this.queryInfo.CreatedBy);
+                query.GitPullRequestSearchCriteria.CreatorId = this.queryInfo.CreatedBy.Value;
             }
 
             return query;

--- a/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
@@ -70,12 +70,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             this.IsPending = this.IsActive && !this.IsSignedOff;
             this.IsCompleted = (this.Reference.Status == PullRequestStatus.Completed);
             this.IsAssignedToMe = this.IsActive && this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef) == 1;
-
-            if (this.IsSignedOff)
-            {
-                this.IsSignedOffByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5)) != 0;
-            }
-
+            this.IsSignedOffByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5)) != 0;
             this.BottomLeftText = this.CreatedBy;
 
             if (this.IterationCount > 1)

--- a/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
             if (this.IsSignedOff)
             {
-                this.IsSignedOffByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5)) == 1;
+                this.IsSignedOffByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5)) != 0;
             }
 
             this.BottomLeftText = this.CreatedBy;

--- a/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             this.IsPending = this.IsActive && !this.IsSignedOff;
             this.IsCompleted = (this.Reference.Status == PullRequestStatus.Completed);
             this.IsAssignedToMe = this.IsActive && this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef) == 1;
-            this.IsSignedOffByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5)) != 0;
+            this.IsSignedOffOrDeclinedByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5 || x.HasDeclined.GetValueOrDefault(false))) != 0;
             this.BottomLeftText = this.CreatedBy;
 
             if (this.IterationCount > 1)
@@ -87,7 +87,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         public bool IsActive { get; set; }
         public bool IsPending { get; set; }
         public bool IsSignedOff { get; set; }
-        public bool IsSignedOffByMe { get; set; }
+        public bool IsSignedOffOrDeclinedByMe { get; set; }
         public bool IsCompleted { get; set; }
         public bool IsWaiting { get; set; }
 

--- a/Source/TeamMate/ViewModels/TileCollectionViewModel.cs
+++ b/Source/TeamMate/ViewModels/TileCollectionViewModel.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
         private IList<WorkItemRowViewModel> GetItemsTowardsCount()
         {
-            // TODO: Get CodeReviews too? How do these surface in the UI?
+            // TODO: Get PullRequests too? How do these surface in the UI?
             var allWorkItems = Tiles.OfType<WorkItemQueryTileViewModel>().Where(wiq => wiq.IncludeInItemCountSummary)
                 .Select(q => q.WorkItemQuery.WorkItems).Where(items => items != null).SelectMany(w => w).Distinct().ToArray();
 

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -6,7 +6,7 @@
         xmlns:tmc="clr-namespace:Microsoft.Tools.TeamMate.Controls"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="Microsoft.Tools.TeamMate.Windows.PullRequestQueryEditorDialog"
         FocusManager.FocusedElement="{Binding ElementName=nameTextBox}"
-        SizeToContent="WidthAndHeight" Height="294"
+        SizeToContent="WidthAndHeight" Height="306"
         >
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}">

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -6,7 +6,7 @@
         xmlns:tmc="clr-namespace:Microsoft.Tools.TeamMate.Controls"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="Microsoft.Tools.TeamMate.Windows.PullRequestQueryEditorDialog"
         FocusManager.FocusedElement="{Binding ElementName=nameTextBox}"
-        SizeToContent="WidthAndHeight" Height="306"
+        SizeToContent="WidthAndHeight"
         >
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}">
@@ -20,10 +20,18 @@
     <Window.Style>
         <StaticResource ResourceKey="LyncDialogStyle"/>
     </Window.Style>
-    <AdornerDecorator>
-        <fwc:DialogPanel Margin="12,0,24,12">
+    <AdornerDecorator RenderTransformOrigin="0.5,0.5" Margin="0,0,0,0">
+        <AdornerDecorator.RenderTransform>
+            <TransformGroup>
+                <ScaleTransform/>
+                <SkewTransform AngleX="0.254"/>
+                <RotateTransform/>
+                <TranslateTransform X="0.679"/>
+            </TransformGroup>
+        </AdornerDecorator.RenderTransform>
+        <fwc:DialogPanel Margin="12,-3,24,10" Width="400">
             <fwc:DialogPanel.ButtonPanel>
-                <fwc:ButtonPanel>
+                <fwc:ButtonPanel Margin="0,4,0,4">
                     <Button x:Name="okButton"
                             Content="OK"
                             IsDefault="True"
@@ -31,7 +39,11 @@
                     <Button Style="{StaticResource LyncButtonStyle}" fw:UI.ButtonType="Cancel" />
                 </fwc:ButtonPanel>
             </fwc:DialogPanel.ButtonPanel>
-            <StackPanel Width="400" Height="230">
+            <StackPanel Margin="0,5,0,59    ">
+                <fwc:ProgressIndicator
+                    Foreground="{StaticResource ApplicationColorBrush}"
+                    Visibility="{Binding Progress.IsRunning,
+                    Converter={x:Static fw:Converters.VisibilityHidden}}" />
                 <TextBlock Style="{StaticResource LyncDialogTitleStyle}" Text="Pull Request Query"/>
                 <tmc:ValidationErrorView />
                 <Grid Margin="0,12,0,0">
@@ -51,41 +63,36 @@
                            Margin="0,0,6,6" Content="Name:"/>
                     <TextBox x:Name="nameTextBox"
                              Grid.Row="0"
-                             Grid.Column="1"
-                             Margin="0,0,0,6"
+                             Margin="82,0,0,6"
                              VerticalContentAlignment="Center"
-                             Text="{Binding Name, ValidatesOnNotifyDataErrors=True}" />
-                    <Label Grid.Row="1"
+                             Text="{Binding Name, ValidatesOnNotifyDataErrors=True}" Grid.ColumnSpan="2" />
+                    <Label
                            Grid.Column="0"
-                           Margin="0,0,6,6" Content="Project:"/>
+                           Margin="0,0,6,6" Content="Project:" Grid.Row="1"/>
                     <Label Grid.Row="2"
                            Grid.Column="0"
                            Margin="0,0,6,6" Content="Assigned To:"/>
                     <Label Grid.Row="3"
                         Grid.Column="0"
                         Margin="0,0,6,-26" Content="Created By:"/>
-                    <Label Grid.Row="4"
+                    <Label Grid.Row="3"
                            Grid.Column="0"
                            Margin="0,31,6,-57" Content="Status:"/>
-                    <ComboBox Grid.Row="1"
+                    <ComboBox
                               Margin="82,0,0,6"
                               ItemsSource="{Binding Project}"
                               SelectedItem="{Binding SelectedProject}"
                               Text="{Binding NewProject, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2" IsEditable="True" />
-                    <ComboBox Grid.Row="2"
+                              Grid.ColumnSpan="2" IsEditable="True" Grid.Row="1" />
+                    <TextBox Grid.Row="2"
                               Margin="82,0,0,6"
-                              ItemsSource="{Binding AssignedTo}"
-                              SelectedItem="{Binding SelectedAssignedTo}"
-                              Text="{Binding NewAssignedTo, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2" IsEditable="True" />
-                    <ComboBox Grid.Row="3"
+                              Text="{Binding AssignedTo, UpdateSourceTrigger=LostFocus}"
+                              Grid.ColumnSpan="2"/>
+                    <TextBox Grid.Row="3"
                               Margin="82,0,0,-26"
-                              ItemsSource="{Binding CreatedBy}"
-                              SelectedItem="{Binding SelectedCreatedBy}"
-                              Text="{Binding NewCreatedBy, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2" IsEditable="True" />
-                    <ComboBox Grid.Row="4"
+                              Text="{Binding CreatedBy, UpdateSourceTrigger=LostFocus}"
+                              Grid.ColumnSpan="2"/>
+                    <ComboBox Grid.Row="3"
                               Margin="82,31,0,-57"
                               ItemTemplate="{StaticResource EnumTemplate}"
                               ItemsSource="{Binding AllReviewStatuses}"

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -57,26 +57,35 @@
                              Text="{Binding Name, ValidatesOnNotifyDataErrors=True}" />
                     <Label Grid.Row="1"
                            Grid.Column="0"
-                           Margin="0,0,6,6" Content="Assigned To:"/>
+                           Margin="0,0,6,6" Content="Project:"/>
                     <Label Grid.Row="2"
+                           Grid.Column="0"
+                           Margin="0,0,6,6" Content="Assigned To:"/>
+                    <Label Grid.Row="3"
                         Grid.Column="0"
                         Margin="0,0,6,-26" Content="Created By:"/>
-                    <Label Grid.Row="3"
+                    <Label Grid.Row="4"
                            Grid.Column="0"
                            Margin="0,31,6,-57" Content="Status:"/>
                     <ComboBox Grid.Row="1"
                               Margin="82,0,0,6"
+                              ItemsSource="{Binding Project}"
+                              SelectedItem="{Binding SelectedProject}"
+                              Text="{Binding NewProject, UpdateSourceTrigger=LostFocus}"
+                              Grid.ColumnSpan="2" IsEditable="True" />
+                    <ComboBox Grid.Row="2"
+                              Margin="82,0,0,6"
                               ItemsSource="{Binding AssignedTo}"
                               SelectedItem="{Binding SelectedAssignedTo}"
                               Text="{Binding NewAssignedTo, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2" />
-                    <ComboBox Grid.Row="2"
+                              Grid.ColumnSpan="2" IsEditable="True" />
+                    <ComboBox Grid.Row="3"
                               Margin="82,0,0,-26"
                               ItemsSource="{Binding CreatedBy}"
                               SelectedItem="{Binding SelectedCreatedBy}"
                               Text="{Binding NewCreatedBy, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2" />
-                    <ComboBox Grid.Row="3"
+                              Grid.ColumnSpan="2" IsEditable="True" />
+                    <ComboBox Grid.Row="4"
                               Margin="82,31,0,-57"
                               ItemTemplate="{StaticResource EnumTemplate}"
                               ItemsSource="{Binding AllReviewStatuses}"

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -78,7 +78,7 @@
                     <Label Grid.Row="3"
                            Grid.Column="0"
                            Margin="0,31,6,-57" Content="Status:"/>
-                    <ComboBox
+                    <ComboBox x:Name="projectTextBox"
                               Margin="82,0,0,6"
                               ItemsSource="{Binding Project}"
                               SelectedItem="{Binding SelectedProject}"

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -86,11 +86,11 @@
                               Grid.ColumnSpan="2" IsEditable="True" Grid.Row="1" />
                     <TextBox Grid.Row="2"
                               Margin="82,0,0,6"
-                              Text="{Binding AssignedTo, UpdateSourceTrigger=LostFocus}"
+                              Text="{Binding UIAssignedTo, UpdateSourceTrigger=LostFocus}"
                               Grid.ColumnSpan="2"/>
                     <TextBox Grid.Row="3"
                               Margin="82,0,0,-26"
-                              Text="{Binding CreatedBy, UpdateSourceTrigger=LostFocus}"
+                              Text="{Binding UICreatedBy, UpdateSourceTrigger=LostFocus}"
                               Grid.ColumnSpan="2"/>
                     <ComboBox Grid.Row="3"
                               Margin="82,31,0,-57"

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml.cs
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Tools.TeamMate.Foundation.Windows.MVVM;
+﻿using Microsoft.Tools.TeamMate.Foundation.Threading;
+using Microsoft.Tools.TeamMate.Foundation.Windows.MVVM;
 using Microsoft.Tools.TeamMate.ViewModels;
 using System.Windows;
 
@@ -23,7 +24,11 @@ namespace Microsoft.Tools.TeamMate.Windows
             if (isValid)
             {
                 PullRequestPickerViewModel viewModel = (PullRequestPickerViewModel)this.DataContext;
-                viewModel.Flush();
+
+                using (viewModel.Progress = new TaskContext())
+                {
+                    viewModel.Flush();
+                }
 
                 this.DialogResult = true;
             }

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml.cs
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml.cs
@@ -24,12 +24,7 @@ namespace Microsoft.Tools.TeamMate.Windows
             if (isValid)
             {
                 PullRequestPickerViewModel viewModel = (PullRequestPickerViewModel)this.DataContext;
-
-                using (viewModel.Progress = new TaskContext())
-                {
-                    viewModel.Flush();
-                }
-
+                viewModel.Flush();
                 this.DialogResult = true;
             }
         }


### PR DESCRIPTION
In a number of cases, PRs happen in a different project than Work Items. This makes it cumbersome to use TeamMate as you'd have to keep flipping the active project.

With this change, we will allow for setting PR queries against any of the connected projects.

We then extend the PR queries to allow for any CreatedBy or AssignedTo based on emails.