### PR TITLE
Scope down list of Projects in PR query editor to only projects within the same active project collection

### DIFF
--- a/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPageViewModel.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             model.Filters.Add(new ListViewFilter("Pending", (o) => ((PullRequestRowViewModel)o).IsPending));
             model.Filters.Add(new ListViewFilter("Waiting", (o) => ((PullRequestRowViewModel)o).IsWaiting));
             model.Filters.Add(new ListViewFilter("Signed Off", (o) => ((PullRequestRowViewModel)o).IsSignedOff));
-            model.Filters.Add(new ListViewFilter("Not Signed Off / Declined By Me", (o) => !((PullRequestRowViewModel)o).IsSignedOffOrDeclinedByMe));
+            model.Filters.Add(new ListViewFilter("Needs Action", (o) => ((PullRequestRowViewModel)o).IsNeedsAction));
             model.Filters.Add(new ListViewFilter("Completed", (o) => ((PullRequestRowViewModel)o).IsCompleted));
 
             model.Fields.Add(ListFieldInfo.Create<string>("CreatedBy", "Created By"));

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -132,7 +132,11 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             {
                 foreach (var project in projects)
                 {
-                    AddProject(project.ProjectName);
+                    // Today we can only handle Projects within the same project collection.
+                    if (this.SessionService.Session.ProjectContext.ProjectInfo.ProjectCollectionUri == project.ProjectCollectionUri)
+                    {
+                        AddProject(project.ProjectName);
+                    }
                 }
             }
         }

--- a/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestRowViewModel.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             this.IsPending = this.IsActive && !this.IsSignedOff;
             this.IsCompleted = (this.Reference.Status == PullRequestStatus.Completed);
             this.IsAssignedToMe = this.IsActive && this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef) == 1;
-            this.IsSignedOffOrDeclinedByMe = this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5 || x.HasDeclined.GetValueOrDefault(false))) != 0;
+            this.IsNeedsAction = !this.IsOwnedByMe && (this.Reference.Reviewers.Count(x => x.Id == this.IdentityRef && (x.Vote == 10 || x.Vote == 5 || x.HasDeclined.GetValueOrDefault(false))) == 0);
             this.BottomLeftText = this.CreatedBy;
 
             if (this.IterationCount > 1)
@@ -87,7 +87,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         public bool IsActive { get; set; }
         public bool IsPending { get; set; }
         public bool IsSignedOff { get; set; }
-        public bool IsSignedOffOrDeclinedByMe { get; set; }
+        public bool IsNeedsAction { get; set; }
         public bool IsCompleted { get; set; }
         public bool IsWaiting { get; set; }
 

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -40,10 +40,6 @@
                 </fwc:ButtonPanel>
             </fwc:DialogPanel.ButtonPanel>
             <StackPanel Margin="0,5,0,59    ">
-                <fwc:ProgressIndicator
-                    Foreground="{StaticResource ApplicationColorBrush}"
-                    Visibility="{Binding Progress.IsRunning,
-                    Converter={x:Static fw:Converters.VisibilityHidden}}" />
                 <TextBlock Style="{StaticResource LyncDialogTitleStyle}" Text="Pull Request Query"/>
                 <tmc:ValidationErrorView />
                 <Grid Margin="0,12,0,0">
@@ -83,15 +79,16 @@
                               ItemsSource="{Binding Project}"
                               SelectedItem="{Binding SelectedProject}"
                               Text="{Binding NewProject, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2" IsEditable="True" Grid.Row="1" />
-                    <TextBox Grid.Row="2"
+                              Grid.ColumnSpan="2" Grid.Row="1" />
+                    <TextBox x:Name="assignedToTextBox"
+                              Grid.Row="2"
                               Margin="82,0,0,6"
                               Text="{Binding UIAssignedTo, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2"/>
+                              Grid.ColumnSpan="2" fw:UI.HintText="Type an email or leave it empty not to filter..."/>
                     <TextBox Grid.Row="3"
                               Margin="82,0,0,-26"
                               Text="{Binding UICreatedBy, UpdateSourceTrigger=LostFocus}"
-                              Grid.ColumnSpan="2"/>
+                              Grid.ColumnSpan="2" fw:UI.HintText="Type an email or leave it empty not to filter..."/>
                     <ComboBox Grid.Row="3"
                               Margin="82,31,0,-57"
                               ItemTemplate="{StaticResource EnumTemplate}"

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml.cs
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml.cs
@@ -1,7 +1,11 @@
 ﻿using Microsoft.Tools.TeamMate.Foundation.Threading;
 using Microsoft.Tools.TeamMate.Foundation.Windows.MVVM;
 using Microsoft.Tools.TeamMate.ViewModels;
+using System;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 
 namespace Microsoft.Tools.TeamMate.Windows
 {


### PR DESCRIPTION
This will mitigate - but not fix yet - issue #94.

* Do some minor UX improvements to the PR query dialog
* Transform PR filter "Not Assigned to Me / Decline" into a proper "Needs Action" filter that also removes PRs created by me