### PR TITLE
Pull Requests: Allow filtering at the tile level

### DIFF
--- a/Source/TeamMate/Model/ProjectContextSerializer.cs
+++ b/Source/TeamMate/Model/ProjectContextSerializer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Tools.TeamMate.Model
             query.Project = e.GetAttribute<string>(Schema.PullRequestProject);
             query.UIAssignedTo = e.GetAttribute<string>(Schema.UIAssignedTo);
             query.UICreatedBy = e.GetAttribute<string>(Schema.UICreatedBy);
+            query.Filter = e.GetAttribute<PullRequestQueryFilter>(Schema.PullRequestFilter);
 
             return query;
         }
@@ -151,6 +152,7 @@ namespace Microsoft.Tools.TeamMate.Model
             e.SetAttribute<string>(Schema.UICreatedBy, query.UICreatedBy);
             e.SetAttribute<string>(Schema.UIAssignedTo, query.UIAssignedTo);
             e.SetAttribute<string>(Schema.PullRequestProject, query.Project);
+            e.SetAttribute<PullRequestQueryFilter>(Schema.PullRequestFilter, query.Filter);
 
             return e;
         }
@@ -430,6 +432,7 @@ namespace Microsoft.Tools.TeamMate.Model
             public const string PullRequestId = "PullRequestId";
             public const string PullRequestProjectId = "PullRequestProjectId";
             public const string PullRequestProject = "PullRequestProject";
+            public const string PullRequestFilter = "PullRequestFilter";
 
             // ProjectSettings Stuff
             public static readonly XName ProjectSettings = "ProjectSettings";

--- a/Source/TeamMate/Model/PullRequestQueryInfo.cs
+++ b/Source/TeamMate/Model/PullRequestQueryInfo.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Tools.TeamMate.Model
         public string UIAssignedTo { get; set; }
 
         public string Project { get; set; }
+
+        public PullRequestQueryFilter Filter { get; set; }
     }
     public enum PullRequestQueryReviewStatus
     {
@@ -36,6 +38,15 @@ namespace Microsoft.Tools.TeamMate.Model
 
         [Description("All")]
         All,
+    }
+
+    public enum PullRequestQueryFilter
+    {
+        [Description("None")]
+        None,
+
+        [Description("Needs Action")]
+        NeedsAction,
     }
 }
 

--- a/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestPickerViewModel.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
         private string name;
         private PullRequestQueryInfo queryInfo;
         private PullRequestQueryReviewStatus reviewStatus;
+        private PullRequestQueryFilter filter;
 
         private string _selectedProject;
         private ObservableCollection<string> _project = new ObservableCollection<string>()
@@ -83,6 +84,12 @@ namespace Microsoft.Tools.TeamMate.ViewModels
             set { SetProperty(ref this.createdBy, value); }
         }
 
+        public PullRequestQueryFilter Filter
+        {
+            get { return this.filter; }
+            set { SetProperty(ref this.filter, value); }
+        }
+
         public IEnumerable Project
         {
             get { return this._project; }
@@ -125,6 +132,7 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.ReviewStatus = this.queryInfo.ReviewStatus;
                 this.UIAssignedTo = this.queryInfo.UIAssignedTo;
                 this.UICreatedBy = this.queryInfo.UICreatedBy;
+                this.Filter = this.queryInfo.Filter;
             }
 
             var projects = this.SettingsService.Settings.Projects;
@@ -150,12 +158,18 @@ namespace Microsoft.Tools.TeamMate.ViewModels
                 this.queryInfo.Project = this.SelectedProject.Trim();
                 this.queryInfo.UIAssignedTo = this.UIAssignedTo;
                 this.queryInfo.UICreatedBy = this.UICreatedBy;
+                this.queryInfo.Filter = this.Filter;
             }
         }
 
         public object AllReviewStatuses
         {
             get { return Enum.GetValues(typeof(PullRequestQueryReviewStatus)); }
+        }
+
+        public object AllFilters
+        {
+            get { return Enum.GetValues(typeof(PullRequestQueryFilter)); }
         }
     }
 }

--- a/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
+++ b/Source/TeamMate/ViewModels/PullRequestQueryViewModel.cs
@@ -107,7 +107,19 @@ namespace Microsoft.Tools.TeamMate.ViewModels
 
                         List<Task<List<GitPullRequestIteration>>> iterationTasks = new List<Task<List<GitPullRequestIteration>>>();
 
-                        var pullRequests = queryAsyncTask.Result.Select(r => CreateViewModel(r, projectContext)).ToArray();
+                        PullRequestRowViewModel[] pullRequests = null;
+                        if (this.queryInfo.Filter == PullRequestQueryFilter.None)
+                        {
+                            pullRequests = queryAsyncTask.Result.Select(r => CreateViewModel(r, projectContext)).ToArray();
+                        }
+                        else if (this.queryInfo.Filter == PullRequestQueryFilter.NeedsAction)
+                        {
+                            pullRequests = queryAsyncTask.Result.Select(r => CreateViewModel(r, projectContext)).Where(x => x.IsNeedsAction).ToArray();
+                        }
+                        else
+                        {
+                            pullRequests = queryAsyncTask.Result.Select(r => CreateViewModel(r, projectContext)).ToArray();
+                        }
 
                         foreach (var pullRequest in pullRequests)
                         {

--- a/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
+++ b/Source/TeamMate/Windows/PullRequestQueryEditorDialog.xaml
@@ -20,7 +20,7 @@
     <Window.Style>
         <StaticResource ResourceKey="LyncDialogStyle"/>
     </Window.Style>
-    <AdornerDecorator RenderTransformOrigin="0.5,0.5" Margin="0,0,0,0">
+    <AdornerDecorator RenderTransformOrigin="0.5,0.5" Height="350">
         <AdornerDecorator.RenderTransform>
             <TransformGroup>
                 <ScaleTransform/>
@@ -94,6 +94,14 @@
                               ItemTemplate="{StaticResource EnumTemplate}"
                               ItemsSource="{Binding AllReviewStatuses}"
                               SelectedItem="{Binding ReviewStatus}" Grid.ColumnSpan="2" />
+                    <Label Grid.Row="3"
+                        Grid.Column="0"
+                        Margin="1,65,5,-91" Content="Filter:"/>
+                    <ComboBox Grid.Row="3"
+                        Margin="82,64,0,-90"
+                        ItemTemplate="{StaticResource EnumTemplate}"
+                        ItemsSource="{Binding AllFilters}"
+                        SelectedItem="{Binding Filter}" Grid.ColumnSpan="2" />
                 </Grid>
             </StackPanel>
         </fwc:DialogPanel>


### PR DESCRIPTION
Let's allow filtering at the tile level to make it easy to spot, for example, only PRs needing action.