### PR TITLE
Publish pdb + exe as part of release

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -101,7 +101,10 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: "**/*.msi"
+        files: |
+          **/*.msi
+          **/*.pdb
+          **/*.exe
         draft: true
         prerelease: true
       env:


### PR DESCRIPTION
Let's make sure we have the exe and pdb so we can easily look at dumps.

Fixes #101