### PR TITLE
Add simple clean.cmd to help clear build leftovers between major work

### DIFF
--- a/Source/clean.cmd
+++ b/Source/clean.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -c "Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }"


### PR DESCRIPTION
This helps remove left-over obj / bin when doing major surgery