### PR TITLE
Drop 'dev' MSI

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,12 +9,9 @@ jobs:
   build:
     strategy:
       matrix:
-        channel: [Dev, Production]
+        channel: [Production]
         targetPlatform: [x86]
         include:
-          - channel: Dev
-            Configuration: Debug
-
           - channel: Production
             Configuration: Release
 

--- a/Source/Setup/Microsoft.Tools.TeamMate.wixproj
+++ b/Source/Setup/Microsoft.Tools.TeamMate.wixproj
@@ -3,12 +3,10 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <Channel Condition=" '$(Configuration)' == 'Debug' ">Dev</Channel>
-    <Channel Condition=" '$(Configuration)' == 'Release' ">Production</Channel>
     <ProductVersion>3.10</ProductVersion>
     <ProjectGuid>d8f90795-e254-441c-b231-d4611e574915</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>Microsoft.Tools.TeamMate.$(Channel)</OutputName>
+    <OutputName>Microsoft.Tools.TeamMate</OutputName>
     <OutputType>Package</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">


### PR DESCRIPTION
We only use the "Production" one, and publishing separate sets of exe / pdb is silly. Let's drop the 'dev' channel. This also speeds up CD, so a bit of upside is not bad.