### PR TITLE
Reduce Resolver Cache memory usage

### DIFF
--- a/Source/TeamMate/Services/VstsConnectionService.cs
+++ b/Source/TeamMate/Services/VstsConnectionService.cs
@@ -190,9 +190,6 @@ namespace Microsoft.Tools.TeamMate.Services
                 projectContext.WorkItemFieldsByName = fields.ToDictionary(f => f.ReferenceName, StringComparer.OrdinalIgnoreCase);
                 projectContext.RequiredWorkItemFieldNames = GetWorkItemFieldsToPrefetch(projectContext.WorkItemFieldsByName);
 
-                this.ResolverService.FetchDataSync(
-                   graphClient);
-
                 return projectContext;
             }
             catch (Exception e)


### PR DESCRIPTION
This is a regression from the PR functionality (https://github.com/microsoft/TeamMate/pull/91). We have a cache of graph objects (user and groups) to provide email resolution in query UX. For customers with very large graphs, lo and behold, we tie up a lot of memory.

We are going to mitigate the memory usage with two approaches:

(1) Instead of caching full graph objects (user and group), let's just cache the data we use. This brings down memory consumption by ~60% on a test machine where there are a lot of objects to cache.
(2) We will only load the resolver cache when it is used. If a customer doesn't use PR functionality at all, it would never light up, so we save the bandwidth, CPU, and memory. Compared to 0.1.8, this change yields ~80% memory savings on a machine with lots of graph objects.

Overall, this will make the PR feature fully pay-for-play as you won't pay any CPU, network, or memory costs unless you use it. And even when you use it, we will use a lot less memory (~60% less in my tests).

Also tested with PR queries and observed the on-demand querying happening. All async and not blocking any UI threads as it was previously.

Fixes #100. 