### PR TITLE
Revert "ci: Use GITHUB_OUTPUT envvar instead of set-output command"

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Get the version
       id: get_version
-      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       shell: bash
 
     - name: Install GitVersion


### PR DESCRIPTION
Reverts microsoft/TeamMate#107. This is causing a CD break.